### PR TITLE
Fix halo2-verifier git dependency

### DIFF
--- a/rsa_contract/Cargo.lock
+++ b/rsa_contract/Cargo.lock
@@ -401,7 +401,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "baby-liminal-extension"
 version = "0.1.0"
-source = "git+https://github.com/Cardinal-Cryptography/aleph-node?branch=halo2-verifier#73f6c0b72720dbae8ba5c0b2108fe99647bc7402"
+source = "git+https://github.com/Cardinal-Cryptography/aleph-node?branch=main#62e42e141529f988500b9fd92df0302a84d8c3b8"
 dependencies = [
  "ink",
  "sp-core 21.0.0",

--- a/rsa_contract/Cargo.lock
+++ b/rsa_contract/Cargo.lock
@@ -401,7 +401,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "baby-liminal-extension"
 version = "0.1.0"
-source = "git+https://github.com/Cardinal-Cryptography/aleph-node?branch=main#62e42e141529f988500b9fd92df0302a84d8c3b8"
+source = "git+https://github.com/Cardinal-Cryptography/aleph-node?rev=f8de357#f8de3576225fa265271837422e215b72702b7b9d"
 dependencies = [
  "ink",
  "sp-core 21.0.0",

--- a/rsa_contract/Cargo.toml
+++ b/rsa_contract/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ink = { version = "5.0.0-rc", default-features = false }
-baby-liminal-extension = { git = "https://github.com/Cardinal-Cryptography/aleph-node", branch = "halo2-verifier", features = ["ink"] }
+baby-liminal-extension = { git = "https://github.com/Cardinal-Cryptography/aleph-node", branch = "main", features = ["ink"] }
 
 [dev-dependencies]
 drink = { version = "0.8.5" }

--- a/rsa_contract/Cargo.toml
+++ b/rsa_contract/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 ink = { version = "5.0.0-rc", default-features = false }
-baby-liminal-extension = { git = "https://github.com/Cardinal-Cryptography/aleph-node", branch = "main", features = ["ink"] }
+baby-liminal-extension = { git = "https://github.com/Cardinal-Cryptography/aleph-node", rev = "f8de357", features = ["ink"] }
 
 [dev-dependencies]
 drink = { version = "0.8.5" }


### PR DESCRIPTION
the `halo2-verifier` branch seems to have been merged into main and is no longer available. Changing branch to `main` seems to fix the following error:

```
⏳ Building contract...
Error: Error invoking `cargo metadata` for ../rsa-challenge-with-halo2/client/../rsa_contract/Cargo.toml

Caused by:
    `cargo metadata` exited with an error:     Updating git repository `https://github.com/Cardinal-Cryptography/aleph-node`
    error: failed to get `baby-liminal-extension` as a dependency of package `rsa_contract v0.1.0 (../rsa-challenge-with-halo2/rsa_contract)`
    
    Caused by:
      failed to load source for dependency `baby-liminal-extension`
    
    Caused by:
      Unable to update https://github.com/Cardinal-Cryptography/aleph-node?branch=halo2-verifier#73f6c0b7
    
    Caused by:
      object not found - no match for id (73f6c0b72720dbae8ba5c0b2108fe99647bc7402); class=Odb (9); code=NotFound (-3)
```