### PR TITLE
Use Docker Compose V2 instead of V1

### DIFF
--- a/launch-chain.sh
+++ b/launch-chain.sh
@@ -71,7 +71,7 @@ export_bootnode_address() {
 }
 
 run_snarkeling_node() {
-  NODE_PUBKEY=$ADMIN_PUBKEY docker-compose -f docker-compose.yml up --remove-orphans -d
+  NODE_PUBKEY=$ADMIN_PUBKEY docker compose -f docker-compose.yml up --remove-orphans -d
   log_progress "✅ Successfully launched snarkeling node"
 }
 


### PR DESCRIPTION
When restarting the chain after computer reboot with ./launch-chain.sh, I get "KeyError: 'ContainerConfig'". It looks like docker-compose cannot create a new container because the name is already used. Replacing "docker-compose" with "docker compose" fixes that. The command "docker-compose" runs Docker Compose V1, which is deprecated, and "docker compose" runs V2 ( https://docs.docker.com/compose/ ).